### PR TITLE
Set up logrotate for icecast service

### DIFF
--- a/icecast/Dockerfile
+++ b/icecast/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG en_US.UTF-8
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y build-essential wget libxslt1-dev libvorbis-dev git
+RUN apt-get install -y build-essential wget libxslt1-dev libvorbis-dev git logrotate
 RUN apt-get clean
 
 RUN git clone https://github.com/karlheyes/icecast-kh.git
@@ -17,6 +17,8 @@ RUN cd icecast-kh; ./configure && make && make install
 ADD icecast.xml /icecast.xml
 RUN useradd --create-home -s /bin/bash icecast
 RUN chown icecast:users /icecast.xml
+
+ADD icecast.conf /etc/logrotate.d/icecast.conf
 
 RUN mkdir -p /usr/local/share/icecast/
 RUN mkdir -p /usr/local/share/icecast/logs

--- a/icecast/icecast.conf
+++ b/icecast/icecast.conf
@@ -1,0 +1,12 @@
+/usr/local/share/icecast/logs/*.log {
+    daily
+    rotate 4
+    size 50M
+    compress
+    delaycompress
+    sharedscripts
+    notifempty
+    postrotate
+        kill -HUP `cat /usr/local/share/icecast/icecast.pid`
+    endscript
+}

--- a/icecast/icecast.xml
+++ b/icecast/icecast.xml
@@ -167,7 +167,7 @@
         <logdir>/usr/local/share/icecast/logs</logdir>
         <webroot>/usr/local/share/icecast/web</webroot>
         <adminroot>/usr/local/share/icecast/admin</adminroot>
-        <!-- <pidfile>/usr/local/share/icecast/icecast.pid</pidfile> -->
+        <pidfile>/usr/local/share/icecast/icecast.pid</pidfile>
         <!-- <ssl_certificate>/usr/local/share/icecast/icecast.pem</ssl_certificate> -->
 
         <!-- Aliases: treat requests for 'source' path as being for 'dest' path


### PR DESCRIPTION
Not 100% sure this is correct -- the container builds and ssh'ing in and running 

```
$ logrotate -d /etc/logrotate.d/icecast.conf
reading config file /etc/logrotate.d/icecast.conf

Handling 1 logs

rotating pattern: /usr/local/share/icecast/logs/*.log  52428800 bytes (4 rotations)
empty log files are not rotated, old logs are removed
considering log /usr/local/share/icecast/logs/access.log
  log does not need rotating
considering log /usr/local/share/icecast/logs/error.log
  log does not need rotating
not running postrotate script, since no logs were rotated
```

appears that there at least aren't syntax errors -- not 100% sure the postrotate call is correct. Per the icecast docs

> Note that on non-win32 platforms, a HUP signal can be sent to Icecast in which the log files are re-opened for appending giving the ability move/remove the log files.

Thoughts?